### PR TITLE
listdetails: have details rendering on click and message icon that do…

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -3,6 +3,6 @@
     "rules": "database.rules.json"
   },
   "hosting": {
-    "public": "public"
+    "public": "src"
   }
 }

--- a/src/components/GroupList.jsx
+++ b/src/components/GroupList.jsx
@@ -21,10 +21,8 @@ class GroupList extends React.Component {
         }
       });
     });
+    const that = this;
   }
-
-  // componentDidMount() {
-  // }
 
   render() {
     return (
@@ -32,7 +30,9 @@ class GroupList extends React.Component {
         <thead>
           <tr>
             <td className="col-md-1">Name</td>
-            <td className="col-md-3">Genre</td>
+            <td className="col-md-2">Genre</td>
+            <td className="col-md-8">Details</td>
+            <td className="col-md-8"></td>
           </tr>
         </thead>
         {this.state.groups.map((el) =>

--- a/src/components/GroupListItem.jsx
+++ b/src/components/GroupListItem.jsx
@@ -1,19 +1,31 @@
 import React from 'react';
-import { browserHistory } from 'react-router';
+// import { browserHistory } from 'react-router';
 
 class GroupListItem extends React.Component {
   constructor(props) {
     super(props);
-    this.handleClick = this.handleClick.bind(this);
+    this.handleDetailsClick = this.handleDetailsClick.bind(this);
+    this.handleMessageClick = this.handleMessageClick.bind(this);
+    this.state = {
+      showDetails: false,
+    };
   }
-  handleClick() {
-    // browserHistory.push('group-details');
+  handleDetailsClick() {
+    this.state.showDetails ? this.state.showDetails = false : this.state.showDetails = true;
+    this.forceUpdate();
   }
+
+  handleMessageClick() {
+    console.warn('handleMessageClick works');
+  }
+
   render() {
     return (
-      <tr onClick={this.handleClick}>
+      <tr>
         <td>{this.props.item.name}</td>
         <td>{this.props.item.genre}</td>
+        <td onClick={this.handleDetailsClick}>{this.state.showDetails ? this.props.item.details : 'Click for More Details'}</td>
+        <td onClick={this.handleMessageClick}><img src="http://www.rcuniverse.com/images/email-icon.jpg" /></td>
       </tr>
     );
   }

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -5,6 +5,8 @@ import GroupList from './GroupList.jsx';
 class Home extends React.Component {
   constructor(props) {
     super(props);
+    const that = this;
+    setTimeout(function () { console.warn('settimeout'); that.forceUpdate(); }, 1000);
   }
   render() {
     return (


### PR DESCRIPTION
…es nothing

I added the setTimeout because the page was rendering before we got our data for the table back from the database. This is a really janky fix but I want to finish out the features before ironing out that kind of stuff.

The other functionality from this update:
Clicking on "click for details" shows the group details in our table instead of taking you to a new page

Added a message icon that I'll have to add functionality to, but ideally whatever it does will happen on that page so we don't need to worry about a separate messaging page.